### PR TITLE
Remove parameter of emit method

### DIFF
--- a/KarrotRouter/Core/DataDrainable.swift
+++ b/KarrotRouter/Core/DataDrainable.swift
@@ -6,9 +6,10 @@
 //  Copyright © 2020 Geektree0101. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 protocol DataDrainable: class {
   
+  var currentContext: DataDrainContext? { get }
   func drain(context: DataDrainContext)
 }

--- a/KarrotRouter/Core/UIViewController+Extension.swift
+++ b/KarrotRouter/Core/UIViewController+Extension.swift
@@ -21,9 +21,8 @@ extension UIViewController {
     }
   }
   
-  func emit(context: DataDrainContext?) {
-    guard let context = context else { return }
-    
+  func emit() {
+    guard let context = self.drainable?.currentContext else { return }
     self.behindViewControllers.forEach({ vc in
       guard let drainable = vc.drainable else { return }
       drainable.drain(context: context)

--- a/KarrotRouter/Scene/Card/CardRouter.swift
+++ b/KarrotRouter/Scene/Card/CardRouter.swift
@@ -57,6 +57,10 @@ extension CardRouter: CardRouteLogic {
 
 extension CardRouter: DataDrainable {
   
+  var currentContext: DataDrainContext? {
+    return cardUpdatedContext
+  }
+  
   func drain(context: DataDrainContext) {
     switch context {
     case let ctx as CardUpdatedDrainContext:

--- a/KarrotRouter/Scene/Card/CardViewController.swift
+++ b/KarrotRouter/Scene/Card/CardViewController.swift
@@ -106,7 +106,7 @@ extension CardViewController {
     self.textView.isEditable = false
     self.card?.content = self.textView.text
     self.textView.resignFirstResponder()
-    self.emit(context: router.cardUpdatedContext)
+    self.emit()
     self.update()
   }
   

--- a/KarrotRouter/Scene/Feed/FeedRouter.swift
+++ b/KarrotRouter/Scene/Feed/FeedRouter.swift
@@ -58,6 +58,10 @@ extension FeedRouter: FeedRouteLogic {
 
 extension FeedRouter: DataDrainable {
   
+  var currentContext: DataDrainContext? {
+    return nil
+  }
+  
   func drain(context: DataDrainContext) {
     switch context {
     case let ctx as CardUpdatedDrainContext:

--- a/KarrotRouter/Scene/Profile/ProfileRouter.swift
+++ b/KarrotRouter/Scene/Profile/ProfileRouter.swift
@@ -59,6 +59,10 @@ extension ProfileRouter: ProfileRouteLogic {
 
 extension ProfileRouter: DataDrainable {
   
+  var currentContext: DataDrainContext? {
+    return nil
+  }
+  
   func drain(context: DataDrainContext) {
     switch context {
     case let ctx as CardUpdatedDrainContext:


### PR DESCRIPTION
Remove the context parameter of emit.
Because it does not need to know the context of the router in the viewcontroller.